### PR TITLE
Agregar banner de anuncios en la pantalla de inicio (v0.4.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 
 Todos los cambios notables en este proyecto se documentarán en este archivo.
 
+## [0.4.2] - 2024-09-20
+
+### Añadido
+-**Anuncions: gregado un banner de anuncios en la pantalla de inicio para recaudar fondos y apoyar el desarrollo continuo de la app.
+
+
+## [0.2.0] - 2024-08-16
+
+### Mejorado
+- Se ha reemplazado el WebView con una nueva y mejorada pantalla para leer los detalles de las noticias.
+
+### Corregido
+- Corrección de errores ortográficos.
+
 ## [0.3.0] - 2024-08-26
 
 ### Añadido

--- a/CHANGELOG_EN.md
+++ b/CHANGELOG_EN.md
@@ -2,9 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.2] - 2024-09-20
+
+### Added
+-**Ads: Added an ad banner on the home screen to raise funds and support ongoing app development.
+
 ## [0.3.0] - 2024-08-26
 
-### Añadido
+### Added
 -**Nuevo Canal de Noticias: Ahora puedes acceder al contenido del Periódico El Hoy, proporcionando una fuente adicional de información actualizada.
 
 ##Mejorado

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
  <uses-permission android:name="android.permission.INTERNET"/>
+ <uses-permission android:name="com.google.android.gms.permission.AD_ID" />
+
     <application
         android:label="Nery News"
         android:name="${applicationName}"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -31,6 +31,9 @@
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
+            <meta-data
+            android:name="com.google.android.gms.ads.APPLICATION_ID"
+            android:value="ca-app-pub-9280953313721436~4487140658"/>
     </application>
     <!-- Required to query activities that can process text, see:
          https://developer.android.com/training/package-visibility?hl=en and

--- a/bin/version_manager.dart
+++ b/bin/version_manager.dart
@@ -1,0 +1,60 @@
+import 'dart:io';
+
+void main(List<String> arguments) {
+  if (arguments.isEmpty) {
+    print('Error: Please provide a version level (major, minor, patch)');
+    exit(1);
+  }
+
+  String levelChange = arguments[0];
+  updateVersion(levelChange);
+}
+
+void updateVersion(String levelChange) {
+  final pubspec = File('pubspec.yaml');
+  if (!pubspec.existsSync()) {
+    print('Error: pubspec.yaml not found');
+    exit(1);
+  }
+
+  String content = pubspec.readAsStringSync();
+  RegExp versionRegex = RegExp(r'version:\s*(\d+)\.(\d+)\.(\d+)\+(\d+)');
+  Match? match = versionRegex.firstMatch(content);
+
+  if (match == null) {
+    print('Error: version not found in pubspec.yaml');
+    exit(1);
+  }
+
+  int major = int.parse(match.group(1)!);
+  int minor = int.parse(match.group(2)!);
+  int patch = int.parse(match.group(3)!);
+
+  switch (levelChange) {
+    case 'major':
+      major++;
+      minor = 0;
+      patch = 0;
+      break;
+    case 'minor':
+      minor++;
+      patch = 0;
+      break;
+    case 'patch':
+      patch++;
+      break;
+    default:
+      print('Error: Invalid version level. Use major, minor, or patch.');
+      exit(1);
+  }
+
+  String newVersionName = '$major.$minor.$patch';
+  String newVersion =
+      '$newVersionName+${DateTime.now().millisecondsSinceEpoch ~/ 1000}';
+
+  // Actualiza la versión en pubspec.yaml
+  content = content.replaceFirst(versionRegex, 'version: $newVersion');
+  pubspec.writeAsStringSync(content);
+
+  print('Updated to version: $newVersion');
+}

--- a/lib/app.ads.txt
+++ b/lib/app.ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-9280953313721436, DIRECT, f08c47fec0942fa0

--- a/lib/homePage/page/home_page.dart
+++ b/lib/homePage/page/home_page.dart
@@ -1,8 +1,12 @@
+import 'dart:developer';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_animate/flutter_animate.dart';
+import 'package:google_mobile_ads/google_mobile_ads.dart';
 import 'package:rd_loca_news/favorites/pages/favorite_page.dart';
 import 'package:rd_loca_news/homePage/page/tab_news_page.dart';
 import 'package:rd_loca_news/settings/pages/setting_page.dart';
+import 'package:rd_loca_news/shared/ad_helper.dart';
 
 class HomePage extends StatefulWidget {
   const HomePage({super.key});
@@ -19,7 +23,7 @@ class _HomePageState extends State<HomePage> {
   ];
 
   int _currentIndex = 0;
-
+  BannerAd? _bannerAd;
   void onTabTapped(int index) {
     setState(() {
       _currentIndex = index;
@@ -27,9 +31,36 @@ class _HomePageState extends State<HomePage> {
   }
 
   @override
+  void initState() {
+    super.initState();
+    BannerAd(
+        adUnitId: AdHelper.bannerAdUnitId,
+        request: const AdRequest(),
+        size: AdSize.banner,
+        listener: BannerAdListener(onAdLoaded: (ad) {
+          setState(() {
+            _bannerAd = ad as BannerAd;
+          });
+        }, onAdFailedToLoad: (ad, err) {
+          log('Falo en cargar el banner add: ${err.message}');
+          ad.dispose();
+        })).load();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: _pages[_currentIndex],
+      body: Column(
+        children: [
+          Expanded(child: _pages[_currentIndex]),
+          if (_bannerAd != null)
+            SizedBox(
+              width: _bannerAd!.size.width.toDouble(),
+              height: _bannerAd!.size.height.toDouble(),
+              child: AdWidget(ad: _bannerAd!),
+            ),
+        ],
+      ),
       bottomNavigationBar: Animate(
         child: BottomNavigationBar(
           currentIndex: _currentIndex,

--- a/lib/homePage/page/tab_news_page.dart
+++ b/lib/homePage/page/tab_news_page.dart
@@ -1,9 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:rd_loca_news/homePage/widgets/news_card.dart';
 
-class TabNewsPage extends StatelessWidget {
+class TabNewsPage extends StatefulWidget {
   const TabNewsPage({super.key});
 
+  @override
+  State<TabNewsPage> createState() => _TabNewsPageState();
+}
+
+class _TabNewsPageState extends State<TabNewsPage> {
   @override
   Widget build(BuildContext context) {
     return DefaultTabController(
@@ -51,7 +56,7 @@ class TabNewsPage extends StatelessWidget {
           ),
           NewsCard(
             newsPaper: 'hoy',
-          )
+          ),
         ]),
       ),
     );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,11 +1,17 @@
 import 'package:flutter/material.dart';
+import 'package:google_mobile_ads/google_mobile_ads.dart';
 import 'package:rd_loca_news/homePage/page/home_page.dart';
 import 'package:rd_loca_news/shared/shared_preference.dart';
 
 final prefs = SharedPreference();
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  // unawaited(MobileAds.instance.initialize());
+  // unawaited(MobileAds.instance.initialize());
+  // unawaited(MobileAds.instance.initialize());
+  MobileAds.instance.initialize();
   await prefs.initPrefs();
+
   runApp(const MainApp());
 }
 

--- a/lib/shared/ad_helper.dart
+++ b/lib/shared/ad_helper.dart
@@ -1,0 +1,15 @@
+class AdHelper {
+  static String get bannerAdUnitId {
+    return 'ca-app-pub-9280953313721436/3874575170';
+  }
+
+  static String get interstitalAdunit {
+    //??TODo cambiar a la mia
+    return 'ca-app-pub-xxxxxx/xxxxxx';
+  }
+
+  static String get rewardedAdUnitId {
+    //??TODo cambiar a la mia
+    return 'ca-app-pub-xxxxxx/xxxxxx';
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -192,6 +192,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  google_mobile_ads:
+    dependency: "direct main"
+    description:
+      name: google_mobile_ads
+      sha256: e2d18992d30b2be77cb6976b931112fc3c4612feffb5eb7a8b036bd7a64934da
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.1.0"
   html:
     dependency: transitive
     description:
@@ -613,6 +621,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.5.1"
+  webview_flutter:
+    dependency: transitive
+    description:
+      name: webview_flutter
+      sha256: "6869c8786d179f929144b4a1f86e09ac0eddfe475984951ea6c634774c16b522"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.8.0"
+  webview_flutter_android:
+    dependency: transitive
+    description:
+      name: webview_flutter_android
+      sha256: "6e64fcb1c19d92024da8f33503aaeeda35825d77142c01d0ea2aa32edc79fdc8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.16.7"
+  webview_flutter_platform_interface:
+    dependency: transitive
+    description:
+      name: webview_flutter_platform_interface
+      sha256: d937581d6e558908d7ae3dc1989c4f87b786891ab47bb9df7de548a151779d8d
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.10.0"
+  webview_flutter_wkwebview:
+    dependency: transitive
+    description:
+      name: webview_flutter_wkwebview
+      sha256: "9c62cc46fa4f2d41e10ab81014c1de470a6c6f26051a2de32111b2ee55287feb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.14.0"
   win32:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: rd_loca_news
 description: "A new Flutter project."
 publish_to: "none"
-version: 0.4.0+1726664920
+version: 0.4.1+1726665585
 
 environment:
   sdk: ">=3.3.1 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: rd_loca_news
 description: "A new Flutter project."
 publish_to: "none"
-version: 0.3.0+574606515
+version: 0.4.0+1726664920
 
 environment:
   sdk: ">=3.3.1 <4.0.0"
@@ -29,3 +29,5 @@ flutter:
 
   assets:
     - assets/
+executables:
+  version_manager: bin/version_manager.dart

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
     sdk: flutter
   flutter_animate: ^4.5.0
   flutter_native_splash: ^2.4.1
+  google_mobile_ads: ^5.1.0
   icons_launcher: ^2.1.7
   share_plus: ^9.0.0
   shared_preferences: ^2.3.1


### PR DESCRIPTION
- Se añadió un banner de anuncios en la pantalla de inicio de Nery News para ayudar a recaudar fondos y continuar con el desarrollo de la app.
- El banner no afecta la experiencia de usuario y permitirá mantener la aplicación de manera sostenible.
- Cambios principales:
     - Implementación del banner de anuncios.
     - Actualización de dependencias necesarias para la integración de los anuncios.